### PR TITLE
fix: Migrate from ESM to CJS

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,4 +1,7 @@
 module.exports = {
   extends: ['@relaycorp/eslint-config'],
   root: true,
+  rules: {
+    'node/file-extension-in-import': 'off',
+  }
 };

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -86,7 +86,7 @@ export default {
   // notifyMode: "failure-change",
 
   // A preset that is used as a base for Jest's configuration
-  preset: "ts-jest/presets/default-esm",
+  preset: "ts-jest/presets/default",
 
   // Run tests from one or more projects
   // projects: null,
@@ -160,12 +160,7 @@ export default {
   // timers: "real",
 
   // A map from regular expressions to paths to transformers
-  transform: {
-    '^.+\\.tsx?$': [
-      'ts-jest',
-      { useESM: true },
-    ],
-  },
+  transform: {},
 
   // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
   // transformIgnorePatterns: [

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "url": "https://relaycorp.tech/"
   },
   "description": "Node.js library to send/receive CloudEvents over HTTP binary or any cloud-specific service like GCP PubSub",
-  "type": "module",
   "main": "build/lib/index.js",
   "typings": "build/lib/index.d.ts",
   "repository": "https://github.com/relaycorp/cloudevents-transport-js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@
 // Do NOT import specific adapters here, because some SDKs do some heavy lifting on import (e.g.,
 // call APIs).
 
-export { makeEmitter } from './lib/emitters.js';
+export { makeEmitter } from './lib/emitters';
 
-export { makeReceiver } from './lib/receivers.js';
-export type { Receiver } from './lib/Receiver.js';
+export { makeReceiver } from './lib/receivers';
+export type { Receiver } from './lib/Receiver';

--- a/src/lib/emitters.spec.ts
+++ b/src/lib/emitters.spec.ts
@@ -1,10 +1,10 @@
 import { jest } from '@jest/globals';
 
-import { CE_SINK_URL, GOOGLE_PUBSUB_TOPIC } from '../testUtils/stubs.js';
+import { CE_SINK_URL, GOOGLE_PUBSUB_TOPIC } from '../testUtils/stubs';
 
 const mockCeBinaryEmitter = Symbol('mockCeBinaryEmitter');
 let wasCeImported = false;
-jest.unstable_mockModule('./ceBinary.js', () => {
+jest.mock<any>('./ceBinary', () => {
   wasCeImported = true;
   return {
     makeCeBinaryEmitter: jest.fn().mockReturnValue(mockCeBinaryEmitter),
@@ -13,14 +13,15 @@ jest.unstable_mockModule('./ceBinary.js', () => {
 
 const mockGooglePubSubEmitter = Symbol('mockGooglePubSubEmitter');
 let wasGooglePubSubImported = false;
-jest.unstable_mockModule('./googlePubSub.ts', () => {
+jest.mock<any>('./googlePubSub', () => {
   wasGooglePubSubImported = true;
   return {
     makeGooglePubSubEmitter: jest.fn().mockReturnValue(mockGooglePubSubEmitter),
   };
 });
 
-const { makeEmitter } = await import('./emitters.js');
+// eslint-disable-next-line import/first
+import { makeEmitter } from './emitters';
 
 describe('makeEmitter', () => {
   test('Transports should be loaded lazily', async () => {

--- a/src/lib/emitters.ts
+++ b/src/lib/emitters.ts
@@ -6,10 +6,10 @@ export async function makeEmitter(transport: string, channel: string): Promise<E
   // Avoid import-time side effects (e.g., expensive API calls) by loading emitter functions lazily
   let emitterMaker: EmitterMaker;
   if (transport === 'ce-http-binary') {
-    const { makeCeBinaryEmitter } = await import('./ceBinary.js');
+    const { makeCeBinaryEmitter } = await import('./ceBinary');
     emitterMaker = makeCeBinaryEmitter;
   } else if (transport === 'google-pubsub') {
-    const { makeGooglePubSubEmitter } = await import('./googlePubSub.js');
+    const { makeGooglePubSubEmitter } = await import('./googlePubSub');
     emitterMaker = makeGooglePubSubEmitter;
   } else {
     throw new Error(`Unsupported emitter type (${transport})`);

--- a/src/lib/googlePubSub.spec.ts
+++ b/src/lib/googlePubSub.spec.ts
@@ -2,19 +2,20 @@ import { jest } from '@jest/globals';
 import type { CloudEvent } from 'cloudevents';
 import { formatISO, getUnixTime, setMilliseconds } from 'date-fns';
 
-import { getPromiseRejection, mockSpy } from '../testUtils/jest.js';
-import { GOOGLE_PUBSUB_TOPIC, EVENT } from '../testUtils/stubs.js';
-import { jsonSerialise } from '../testUtils/json.js';
+import { getPromiseRejection, mockSpy } from '../testUtils/jest';
+import { GOOGLE_PUBSUB_TOPIC, EVENT } from '../testUtils/stubs';
+import { jsonSerialise } from '../testUtils/json';
 
 const mockPublishMessage = mockSpy(jest.fn<any>());
 const mockTopic = jest.fn<any>().mockReturnValue({ publishMessage: mockPublishMessage });
-jest.unstable_mockModule('@google-cloud/pubsub', () => ({
+jest.mock<any>('@google-cloud/pubsub', () => ({
   // eslint-disable-next-line @typescript-eslint/naming-convention
   PubSub: jest.fn<any>().mockReturnValue({
     topic: mockTopic,
   }),
 }));
-const { makeGooglePubSubEmitter, convertGooglePubSubMessage } = await import('./googlePubSub.js');
+// eslint-disable-next-line import/first
+import { makeGooglePubSubEmitter, convertGooglePubSubMessage } from './googlePubSub';
 
 describe('makeGooglePubSubEmitter', () => {
   describe('Message', () => {

--- a/src/lib/googlePubSub.ts
+++ b/src/lib/googlePubSub.ts
@@ -3,7 +3,7 @@ import { google } from '@google-cloud/pubsub/build/protos/protos.js';
 import { CloudEvent, type CloudEventV1, type EmitterFunction, type Headers } from 'cloudevents';
 import { getUnixTime } from 'date-fns';
 
-import { compileSchema } from '../utils/ajv.js';
+import { compileSchema } from '../utils/ajv';
 
 import IPubsubMessage = google.pubsub.v1.IPubsubMessage;
 

--- a/src/lib/receivers.spec.ts
+++ b/src/lib/receivers.spec.ts
@@ -2,21 +2,22 @@ import { jest } from '@jest/globals';
 
 const mockCeBinaryConverter = Symbol('mockCeBinaryConverter');
 let wasCeImported = false;
-jest.unstable_mockModule('./ceBinary.js', () => {
+jest.mock<any>('./ceBinary', () => {
   wasCeImported = true;
   return { convertCeBinaryMessage: mockCeBinaryConverter };
 });
 
 const mockGooglePubSubConverter = Symbol('mockGooglePubSubConverter');
 let wasGooglePubSubImported = false;
-jest.unstable_mockModule('./googlePubSub.ts', () => {
+jest.mock<any>('./googlePubSub', () => {
   wasGooglePubSubImported = true;
   return {
     convertGooglePubSubMessage: mockGooglePubSubConverter,
   };
 });
 
-const { makeReceiver } = await import('./receivers.js');
+// eslint-disable-next-line import/first
+import { makeReceiver } from './receivers.js';
 
 describe('makeReceiver', () => {
   test('Transports should be load lazily', async () => {

--- a/src/lib/receivers.spec.ts
+++ b/src/lib/receivers.spec.ts
@@ -17,7 +17,7 @@ jest.mock<any>('./googlePubSub', () => {
 });
 
 // eslint-disable-next-line import/first
-import { makeReceiver } from './receivers.js';
+import { makeReceiver } from './receivers';
 
 describe('makeReceiver', () => {
   test('Transports should be load lazily', async () => {

--- a/src/lib/receivers.ts
+++ b/src/lib/receivers.ts
@@ -1,4 +1,4 @@
-import type { Receiver } from './Receiver.js';
+import type { Receiver } from './Receiver';
 
 export async function makeReceiver(transport: string): Promise<Receiver> {
   // Avoid import-time side effects (e.g., expensive API calls) by loading emitter functions lazily

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,8 @@
 {
   "extends": "@relaycorp/shared-config",
   "compilerOptions": {
-    "experimentalDecorators": true,
-    "module": "esnext",
     "outDir": "build/lib",
     "rootDir": "src",
-    "target": "es2021",
-    "lib": ["es2022", "dom"],
-    "types": ["node", "jest"],
-    "typeRoots": ["node_modules/@types"]
   },
   "include": ["src/**/*.ts", "src/**/*.mjs"]
 }


### PR DESCRIPTION
So we can use it in https://github.com/relaycorp/relaynet-internet-gateway/pull/1082

BREAKING CHANGE: Some code bases may need to make changes to import/mock this library as a CJS project.